### PR TITLE
Rename the default output BUILD directory  for synthesis from osdla_syn_<timestamp> …

### DIFF
--- a/syn/scripts/syn_launch.sh
+++ b/syn/scripts/syn_launch.sh
@@ -24,7 +24,7 @@ DEFAULT_FLOW_CONFIG=$FLOW_ROOT/default_config.sh
 timestamp=$(date +%Y%m%d_%H%M)
 config="./config.sh"
 mode="wlm"
-build="osdla_syn_$timestamp"
+build="nvdla_syn_$timestamp"
 modules=""
 restore_db=""
 


### PR DESCRIPTION
…to nvdla_syn_<timestamp>. Cosmetic change.