### PR TITLE
Removed define for @array, as required in current perl

### DIFF
--- a/tools/bin/tmake
+++ b/tools/bin/tmake
@@ -36,7 +36,7 @@ GetOptions (
              "clober|clean"      => \$clobber,
            ) or die "Unrecognized options @ARGV";
 
-push @build, "verif" unless defined @build;
+push @build, "verif" unless @build;
 #=============================
 ## Global Variables
 #=============================


### PR DESCRIPTION
I tried to get to perl 5.8.8, but was not successful in Ubuntu.  Still got:

Can't use 'defined(@array)' (Maybe you should just omit the defined()?) at ./tools/bin/tmake line 39.

Took their advice.  Checked, "verif" is pushed if no -build option.
