### PR TITLE
csb_master: add missing  'valid' in core_resp_pvld

### DIFF
--- a/vmod/nvdla/csb_master/NV_NVDLA_csb_master.v
+++ b/vmod/nvdla/csb_master/NV_NVDLA_csb_master.v
@@ -1511,7 +1511,8 @@ assign core_resp_pd = ( ({34 {cfgrom_resp_valid}} & cfgrom_resp_pd)
 #endif
                       | ({34 {dummy_resp_valid}} & dummy_resp_pd));
 
-assign core_resp_pvld = glb_resp_valid |
+assign core_resp_pvld = cfgrom_resp_valid |
+                        glb_resp_valid |
                         mcif_resp_valid |
 #ifdef NVDLA_SECONDARY_MEMIF_ENABLE
                         cvif_resp_valid |


### PR DESCRIPTION
I am testing accessing CSB registers on Zynq UltraScale+ platform through AXI4 to APB bus bridge. I found that accessing CFGROM ends up with lockup state. If APB IP core is not configured to handle timeout, the entire system locks up, including JTAG and system reset / power cycle is required.

This modification should fix the problem.