### PR TITLE
Fix CMOD Makefile calling system GCC linker instead of user GCC

### DIFF
--- a/cmod/Makefile
+++ b/cmod/Makefile
@@ -159,7 +159,7 @@ CPPFLAGS ?= $(INC_FLAGS) -MMD -MP -fPIC -Wall -Werror -DSC_INCLUDE_DYNAMIC_PROCE
 LDFLAGS ?= -shared $(addprefix -l,$($(notdir $(SYSTEMC_LIBRARIES)):lib%.so=%)) $(LD_FLAGS)
 
 $(BUILD_DIR)/$(TARGET): $(OBJS) 
-	$(CC) $(OBJS) -o $@ $(LDFLAGS) -L$(BUILD_DIR)
+	$(GCC) $(OBJS) -o $@ $(LDFLAGS) -L$(BUILD_DIR)
 
 default: $(BUILD_DIR)/$(TARGET) install
 	@echo "=============================================="


### PR DESCRIPTION
It's not big problem, but I think it's just overlooked use of `$(CC)`. I checked with `grep -Rw CC`, and it's defined nowhere therefore it defaults to `/usr/bin/cc` which is 'out of control'.

Good idea would be defining `CC := $(GCC)` in make/common.make or somewhere else.