### PR TITLE
Fix deadlock when CSB slave responds in same cycle as request

### DIFF
--- a/vmod/nvdla/apb2csb/NV_NVDLA_apb2csb.v
+++ b/vmod/nvdla/apb2csb/NV_NVDLA_apb2csb.v
@@ -82,7 +82,7 @@ always @(posedge pclk or negedge prstn) begin
   if (!prstn) begin
     rd_trans_low <= 1'b0;
   end else begin
-    if(nvdla2csb_valid & rd_trans_low) 
+    if(nvdla2csb_valid) 
         rd_trans_low <= 1'b0;
     else if (csb2nvdla_ready & rd_trans_vld) 
         rd_trans_low <= 1'b1;


### PR DESCRIPTION
NVDLA's own CSB slaves are 1-cycle (registered output, e.g. [`glb2csb_resp_valid <= rsp_vld`](https://github.com/nvdla/hw/blob/master/vmod/nvdla/glb/NV_NVDLA_GLB_csb.v#L240-L246)), so NVDLA-only integrations don't trigger this. The bug bites integrators that wire this adapter to a 0-cycle CSB slave (simple register memories, debug ports, test fixtures).

Thanks!
Flavien